### PR TITLE
Use the correct maven plugin repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
 
   <!-- Include the Maven Plugin Repository -->
   <pluginRepositories>
-   <pluginRepository>
+    <pluginRepository>
       <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <url>https://oss.sonatype.org/content/groups/public/</url>
     </pluginRepository>
   </pluginRepositories>
          
@@ -141,7 +141,7 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0</version>
         <configuration>
           <cdapArtifacts>
             <parent>system:wrangler-transform[3.0.0,10.0.0)</parent>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
       <plugin>
         <groupId>co.cask</groupId>
         <artifactId>cdap-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.1</version>
         <configuration>
           <cdapArtifacts>
             <parent>system:wrangler-transform[3.0.0,10.0.0)</parent>


### PR DESCRIPTION
Use the correct maven plugin repository. `mvn clean package -DskipTests` Fails when trying to fetch the cdap-maven-plugin:
```
[ERROR] Failed to execute goal co.cask:cdap-maven-plugin:1.0.0-SNAPSHOT:create-plugin-json (create-artifact-config) on project simple-udds: Execution create-artifact-config of goal co.cask:cdap-maven-plugin:1.0.0-SNAPSHOT:create-plugin-json failed: Plugin co.cask:cdap-maven-plugin:1.0.0-SNAPSHOT or one of its dependencies could not be resolved: Failure to find org.json:json:jar:20180813 in https://oss.sonatype.org/content/repositories/snapshots/ was cached in the local repository, resolution will not be reattempted until the update interval of sonatype has elapsed or updates are forced -> [Help 1]
```

This is the same fix as in the wrangler repo: https://github.com/data-integrations/wrangler/pull/283