### PR TITLE
Modify parents for the cdap-maven-plugin packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <configuration>
           <cdapArtifacts>
             <parent>system:wrangler-transform[4.0.0,5.0.0)</parent>
+            <parent>system:wrangler-service[4.0.0,5.0.0)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>


### PR DESCRIPTION
Added wrangler-service to the parents for cdap-maven-plugin packaging.

Testing: 
The UDD is working - 
<img width="1726" height="951" alt="Screenshot 2025-07-31 at 12 43 50 PM" src="https://github.com/user-attachments/assets/7c9a0e14-7426-40c9-ad21-ff974f11ace0" />
